### PR TITLE
Fix array indexing bug in uint8_to_bed_parallel.py

### DIFF
--- a/umap/uint8_to_bed_parallel.py
+++ b/umap/uint8_to_bed_parallel.py
@@ -366,14 +366,14 @@ class Int8Handler:
         unimap_diff = np.diff(np.array(ar_quant > 0, dtype=int))
         poses_start, = np.where(unimap_diff == 1)
         poses_end, = np.where(unimap_diff == -1)
-        if len(poses_start) != len(poses_end):
-            if len(poses_start) > len(poses_end):
-                poses_end = np.append(poses_end, [len(uniquely_mappable)])
-            else:
-                poses_start = np.append([0], poses_start)
-        elif uniquely_mappable[0] == 1:
+        if uniquely_mappable[0] > 0:
+            # If the first element of uniquely_mappable is nonzero,
+            # then poses_start is missing the start position of the first "run"
             poses_start = np.append([0], poses_start)
-            poses_end = np.append(poses_end, [len(uniquely_mappable)])
+        if uniquely_mappable[-1] > 0:
+            # If the last element of uniquely_mappable is nonzero,
+            # then poses_end is missing the end position of the last "run".
+            poses_end = np.append(poses_end, [len(uniquely_mappable) - 1])
         for ind_st in range(len(poses_start)):
             pos_st = poses_start[ind_st] + 1
             pos_end = poses_end[ind_st] + 1


### PR DESCRIPTION
# Overview

Problem: An IndexError can be raised on [line 384](https://github.com/hoffmangroup/umap/blob/03f810e3dd8b81b534e5198062e099973edf5823/umap/uint8_to_bed_parallel.py#L384) of uint8_to_bed_parallel.py when trying to access an out-of-bounds index of `ar_quant`:

```python
out_link.write(str(ar_quant[each_pos]) + "\n")
```

Fix: this commit both simplifies the logic of the code and fixes the bug.

# Details

Relevant variables
- `uniquely_mappable`: single read mappability array of length N
- `ar_quant`: multi-read mappability array of length N (length of chromosome)
- `unimap_diff`: array of length N - 1  
- `poses_start`: start position of non-zero "runs"; initially (line 367) calculated as a value 1 less than the desired 0-based (start-open, end-closed) index
- `poses_end`: end position of non-zero "runs"; initially (line 368) calculated as a value 1 less than the desired 0-based (start-open, end-closed) index

Here, I annotate the original code to clarify its logic.

```python
if len(poses_start) != len(poses_end):
    # The length of poses_start may be different than the length of poses_end if the
    # first and last elements of ar_quant are not both zero or nonzero.
    if len(poses_start) > len(poses_end):
        # - If the last element of ar_quant is nonzero, then
        #   poses_end is missing the end position of the last run, because the last run did not "finish."
        # - Consequently, we append an end position to poses_end. At this point in the code, 
        #   poses_end contains indices of value 1 less than the desired 0-based (start-open, end-closed) index.
        #   So the value appended should be (len(uniquely_mappable) - 1), not len(uniquely_mappable).
        poses_end = np.append(poses_end, [len(uniquely_mappable)])
    else:
        # - If the first element of ar_quant is nonzero, then
        #   poses_start is missing the start position of the first run.
        # - Consequently, we insert a start position of 0 to poses_start.
        poses_start = np.append([0], poses_start)
elif uniquely_mappable[0] == 1:
    # This code is only encountered if the first element of ar_quant is nonzero
    # AND the last element of ar_quant is also nonzero, such that:
    # - poses_start is missing the start position of the first run. Consequently, we insert a start position of 0 to poses_start.
    # - poses_end is missing the end position of the last run. At this point in the code, 
    #   poses_end contains indices of value 1 less than the desired 0-based (start-open, end-closed) index.
    #   So the value appended should be (len(uniquely_mappable) - 1), not len(uniquely_mappable).
    poses_start = np.append([0], poses_start)
    poses_end = np.append(poses_end, [len(uniquely_mappable)])
```

Note that whether the length of the arrays `poses_end` and `poses_start` are the same is ultimately not relevant. We simply need to add a start position of 0 if the first element of `ar_quant` is non-zero, and add an end position of `len(uniquely_mappable) - 1` if the last element of `ar_quant` is non-zero. This entire code block can therefore be simplifed as follows:
```python
if uniquely_mappable[0] > 0:
    poses_start = np.append([0], poses_start)
if uniquely_mappable[-1] > 0:
    poses_end = np.append(poses_end, [len(uniquely_mappable) - 1])
```

Example for a kmer size of 1
- `uniquely_mappable = [ 0,  0,  1,  1,  1,  0,  0,  1,  1 ]`
- `ar_quant = [ 0,  0,  1,  1,  1,  0,  0,  1,  1 ]`
- `unimap_diff = [ 0,  1,  0,  0, -1,  0,  1,  0]`
- `poses_start = [1, 6]`
- `poses_end = [4]` --> extended to `poses_end = [4, 8]`

Desired wiggle output
```
fixedStep chrom=chrom start=3 step=1 span=1
ar_quant[2]
ar_quant[3]
ar_quant[4]
fixedStep chrom=chrom start=8 step=1 span=1
ar_quant[7]
ar_quant[8]
```

Working backwards, we need `pos_st = [2, 7]` and `pos_end = [5, 9]` for the following loop (lines 383-384) to work as intended:
```
for each_pos in range(pos_st, pos_end):
    out_link.write(str(ar_quant[each_pos]) + "\n")
````

Lines 378 and 379 add a value of 1 to each of the positions from poses_start and poses_end, therefore giving the desired result.
